### PR TITLE
fix：去掉fcmToken代理方法中参数非空关键字

### DIFF
--- a/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -153,7 +153,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 #pragma mark - Firebase Messaging Delegate
 
 - (void)messaging:(nonnull FIRMessaging *)messaging
-    didReceiveRegistrationToken:(nonnull NSString *)fcmToken {
+    didReceiveRegistrationToken:(NSString *)fcmToken {
   // Don't crash if the token is reset.
   if (fcmToken == nil) {
     return;


### PR DESCRIPTION
解决iOS模拟器和真机编译报错问题